### PR TITLE
WIP: Bump all versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ project/plugins/project/
 .bloop
 .metals
 project/metals.sbt
+project/project

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ zio-cassandra
 A ZIO wrapper around the Datastax Cassandra driver
 --------------------------------------------------
 
-* Scala 2.13.4
-* Datastax java driver 4.10.0
-* ZIO 1.0.4-2
+* Scala 2.13.6
+* Datastax java driver 4.12.0
+* ZIO 1.0.9
 
 Installation
 ------------

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val ALL_SCALA  = Seq(MAIN_SCALA)
 
 val DATASTAX_JAVA_CASSANDRA_VERSION = "4.12.0"
 
-val ZIO_VERSION = "1.0.7"
+val ZIO_VERSION = "1.0.9"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ name := "zio-cassandra"
 
 val ZIO_CASSANDRA_VERSION = "0.4.1"
 
-val MAIN_SCALA = "2.13.5"
+val MAIN_SCALA = "2.13.6"
 val ALL_SCALA  = Seq(MAIN_SCALA)
 
-val DATASTAX_JAVA_CASSANDRA_VERSION = "4.11.0"
+val DATASTAX_JAVA_CASSANDRA_VERSION = "4.12.0"
 
 val ZIO_VERSION = "1.0.7"
 

--- a/core/src/main/scala/palanga/zio/cassandra/session/ZCqlLayer.scala
+++ b/core/src/main/scala/palanga/zio/cassandra/session/ZCqlLayer.scala
@@ -7,7 +7,7 @@ import zio.console.Console
 
 object ZCqlLayer {
 
-  def default: ZLayer[Console with Clock, CassandraException, ZCqlSession] = from(shouldCreateKeyspace = true)
+  def default = from(shouldCreateKeyspace = true)
 
   def from(
     host: String = "127.0.0.1",
@@ -15,7 +15,7 @@ object ZCqlLayer {
     keyspace: String = "test",
     datacenter: String = "datacenter1",
     shouldCreateKeyspace: Boolean = false,
-  ): ZLayer[Console with Clock, CassandraException, ZCqlSession] =
+  ) =
     ZCqlManaged.from(host, port, keyspace, datacenter, shouldCreateKeyspace).toLayer
 
 }

--- a/core/src/main/scala/palanga/zio/cassandra/session/ZCqlManaged.scala
+++ b/core/src/main/scala/palanga/zio/cassandra/session/ZCqlManaged.scala
@@ -7,8 +7,7 @@ import zio.console.{ putStrLn, Console }
 
 private[cassandra] object ZCqlManaged {
 
-  def default: ZManaged[Console with Clock, CassandraException, ZCqlSession.Service] =
-    from(shouldCreateKeyspace = true)
+  def default = from(shouldCreateKeyspace = true)
 
   def from(
     host: String = "127.0.0.1",
@@ -16,8 +15,8 @@ private[cassandra] object ZCqlManaged {
     keyspace: String = "test",
     datacenter: String = "datacenter1",
     shouldCreateKeyspace: Boolean = false,
-  ): ZManaged[Console with Clock, CassandraException, ZCqlSession.Service] =
-    ZCqlRaw.from(host, port, keyspace, datacenter, shouldCreateKeyspace).toManaged(closeSession)
+  ) =
+    ZCqlRaw.from(host, port, keyspace, datacenter, shouldCreateKeyspace) //.toManaged(closeSession)
 
   private def closeSession(session: ZCqlSession.Service) =
     (for {

--- a/core/src/main/scala/palanga/zio/cassandra/session/ZCqlRaw.scala
+++ b/core/src/main/scala/palanga/zio/cassandra/session/ZCqlRaw.scala
@@ -24,7 +24,7 @@ private[session] object ZCqlRaw {
     keyspace: String = "test",
     datacenter: String = "datacenter1",
     shouldCreateKeyspace: Boolean = false,
-  ): ZIO[Console with Clock, CassandraException, ZCqlSession.Service] =
+  ) =
     (for {
       _       <- putStrLn("Opening cassandra session...")
       session <- fromCqlSession(

--- a/examples/src/main/scala/examples/SimpleExample.scala
+++ b/examples/src/main/scala/examples/SimpleExample.scala
@@ -47,7 +47,7 @@ object SimpleExample {
   /**
    * The simplest and better way of creating a session is:
    */
-  val sessionLayer: ZLayer[Console with Clock, CassandraException, ZCqlSession] =
+  val sessionLayer =
     palanga.zio.cassandra.session.layer
       .from(
         "127.0.0.1",
@@ -58,7 +58,7 @@ object SimpleExample {
   /**
    * But it's not the only way to create a session:
    */
-  val managedSession: ZManaged[Console with Clock, CassandraException, ZCqlSession.Service] =
+  val managedSession =
     palanga.zio.cassandra.session.managed
       .from(
         "127.0.0.1",
@@ -66,7 +66,7 @@ object SimpleExample {
         "painters_keyspace",
       )
 
-  val rawSession: ZIO[Console with Clock, CassandraException, ZCqlSession.Service] =
+  val rawSession =
     palanga.zio.cassandra.session.raw
       .from(
         "127.0.0.1",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.0
+sbt.version = 1.5.4


### PR DESCRIPTION
Hello Andres

I'm using your project as a dependency, so have to maintain it time to time. 
I bumped versions in my top project and wanted to bump in yours.

However, bumping ZIO from 1.0.7 to 1.0.9 yields in some compilation errors. I did the following:

- Removed type annotations in few methods. It seems like ZIO team changes API periodically so it may be a good time to revise your intent types or leave them unconstrained for auto inference
- Removed annotations in the Simple Example for the same reason
- Upd readme 

I'm marking this project as a WIP for now. You may either merge it and update on your own, or give me your directions on how would you wish to treat those type inference errors.

Best,
Boris